### PR TITLE
[Refactor] SessionManager 리팩토링

### DIFF
--- a/feedback-iOS/feedback-iOS/Presentation/Model/MessageData.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/MessageData.swift
@@ -1,0 +1,13 @@
+//
+//  MessageData.swift
+//  feedback-iOS
+//
+//  Created by Chandrala on 11/8/24.
+//
+
+import UIKit
+
+struct MessageData: Codable {
+  let message: String
+  let data: Data
+}

--- a/feedback-iOS/feedback-iOS/Presentation/Model/PeerInfoManager.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/PeerInfoManager.swift
@@ -1,0 +1,31 @@
+//
+//  PeerInfoManager.swift
+//  feedback-iOS
+//
+//  Created by Chandrala on 11/8/24.
+//
+
+import MultipeerConnectivity
+
+final class PeerInfoManager {
+  static let shared = PeerInfoManager()
+  private init() {}
+  
+  var connectedUserInfos: [UserInfo] = []
+  var myFeedbackDatas: [SkillSet] = []
+  var resultData: SkillSet = SkillSet(categories: [communication, selfDevelopment, problemSolving, teamwork, leadership])
+  
+  func addPeerInfo(_ userInfo: UserInfo) {
+    connectedUserInfos.append(userInfo)
+    print("Peer 정보 추가됨: \(userInfo)")
+  }
+  
+  func updateFeedback(with feedbackData: SkillSet) {
+    myFeedbackDatas.append(feedbackData)
+    for (categoryIndex, category) in feedbackData.categories.enumerated() {
+      for (traitIndex, trait) in category.traits.enumerated() {
+        resultData.categories[categoryIndex].traits[traitIndex].count += trait.count
+      }
+    }
+  }
+}

--- a/feedback-iOS/feedback-iOS/Presentation/Model/PeerInfoManager.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/PeerInfoManager.swift
@@ -16,8 +16,10 @@ final class PeerInfoManager {
   var resultData: SkillSet = SkillSet(categories: [communication, selfDevelopment, problemSolving, teamwork, leadership])
   
   func addPeerInfo(_ userInfo: UserInfo) {
-    connectedUserInfos.append(userInfo)
-    print("Peer 정보 추가됨: \(userInfo)")
+    if !connectedUserInfos.contains(where: { $0.peerID.displayName == userInfo.peerID.displayName }) {
+      connectedUserInfos.append(userInfo)
+      print("Peer 정보 추가됨: \(userInfo)")
+    }
   }
   
   func updateFeedback(with feedbackData: SkillSet) {
@@ -27,5 +29,12 @@ final class PeerInfoManager {
         resultData.categories[categoryIndex].traits[traitIndex].count += trait.count
       }
     }
+  }
+  
+  func reset() {
+    connectedUserInfos.removeAll()
+    myFeedbackDatas.removeAll()
+    resultData = SkillSet(categories: [communication, selfDevelopment, problemSolving, teamwork, leadership])
+    print("PeerInfoManager 초기화 완료")
   }
 }

--- a/feedback-iOS/feedback-iOS/Presentation/Model/SessionDataReceiver.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/SessionDataReceiver.swift
@@ -53,9 +53,6 @@ final class SessionDataReceiver {
       case "feedbackCompleted":
         SessionManager.shared.feedbackCompletionCount += 1
         print("피드백 완료 인원 추가")
-        if SessionManager.shared.isHost {
-          SessionManager.shared.checkAllFeedbackCompleted()
-        }
         
       case "showResults":
         DispatchQueue.main.async {

--- a/feedback-iOS/feedback-iOS/Presentation/Model/SessionDataReceiver.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/SessionDataReceiver.swift
@@ -1,0 +1,70 @@
+//
+//  SessionDataReceiver.swift
+//  feedback-iOS
+//
+//  Created by Chandrala on 11/8/24.
+//
+
+import MultipeerConnectivity
+
+final class SessionDataReceiver {
+  static let shared = SessionDataReceiver()
+  private init() {}
+  
+  func processReceivedData(_ data: Data, from peerID: MCPeerID) {
+    if let receivedMessageData = try? JSONDecoder().decode(MessageData.self, from: data) {
+      print("수신한 메시지: \(receivedMessageData.message)")
+      
+      switch receivedMessageData.message {
+      case "localUserInfo":
+        if let receivedUserInfo = try? JSONDecoder().decode(
+          UserInfo.self,
+          from: receivedMessageData.data
+        ) {
+          PeerInfoManager.shared.addPeerInfo(receivedUserInfo)
+        }
+        
+      case "startFeedback":
+        if let allUserInfoData = try? JSONDecoder().decode(
+          [UserInfo].self,
+          from: receivedMessageData.data
+        ) {
+          PeerInfoManager.shared.connectedUserInfos = allUserInfoData
+          DispatchQueue.main.async {
+            SessionManager.shared.onPushDataReceived?()
+          }
+        }
+        
+      case "sendFeedback":
+        if let receivedFeedbackData = try? JSONDecoder().decode(SkillSet.self, from: receivedMessageData.data) {
+          PeerInfoManager.shared.myFeedbackDatas.append(receivedFeedbackData)
+
+          PeerInfoManager.shared.resultData = SkillSet(categories: [communication, selfDevelopment, problemSolving, teamwork, leadership])
+
+          for feedbackData in PeerInfoManager.shared.myFeedbackDatas {
+            for (categoryIndex, category) in feedbackData.categories.enumerated() {
+              for (traitIndex, trait) in category.traits.enumerated() {
+                PeerInfoManager.shared.resultData.categories[categoryIndex].traits[traitIndex].count += trait.count
+              }
+            }
+          }
+        }
+        
+      case "feedbackCompleted":
+        SessionManager.shared.feedbackCompletionCount += 1
+        print("피드백 완료 인원 추가")
+        if SessionManager.shared.isHost {
+          SessionManager.shared.checkAllFeedbackCompleted()
+        }
+        
+      case "showResults":
+        DispatchQueue.main.async {
+          SessionManager.shared.onPushDataReceived?()
+        }
+        
+      default:
+        print("알 수 없는 메시지: \(receivedMessageData.message)")
+      }
+    }
+  }
+}

--- a/feedback-iOS/feedback-iOS/Presentation/Model/SessionDataSender.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/SessionDataSender.swift
@@ -1,0 +1,26 @@
+//
+//  SessionDataSender.swift
+//  feedback-iOS
+//
+//  Created by Chandrala on 11/8/24.
+//
+
+import MultipeerConnectivity
+
+final class SessionDataSender {
+  static let shared = SessionDataSender()
+  private init() {}
+  
+  func sendData(_ data: Data, message: String, to: [MCPeerID]) {
+    guard !SessionManager.shared.session.connectedPeers.isEmpty else { return }
+    let messageData = MessageData(message: message, data: data)
+    
+    do {
+      let encodedMessageData = try JSONEncoder().encode(messageData)
+      try SessionManager.shared.session.send(encodedMessageData, toPeers: to, with: .reliable)
+      print("데이터 전송 성공: \(message)")
+    } catch {
+      print("데이터 전송 실패: \(error.localizedDescription)")
+    }
+  }
+}

--- a/feedback-iOS/feedback-iOS/Presentation/Model/SessionManager.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/SessionManager.swift
@@ -1,33 +1,13 @@
+//
+//  SessionManager.swift
+//  feedback-iOS
+//
+//  Created by Chandrala on 11/8/24.
+//
+
 import MultipeerConnectivity
 
-struct MessageData: Codable {
-  let message: String
-  let data: Data
-}
-
-struct UserInfo: Codable, Equatable, Hashable {
-  let uuid: String
-  let peerID: String
-  let role: String
-  
-  init(uuid: String, peerID: MCPeerID, role: String) {
-    self.uuid = uuid
-    self.peerID = peerID.displayName
-    self.role = role
-  }
-  
-  static func == (lhs: UserInfo, rhs: UserInfo) -> Bool {
-    return lhs.uuid == rhs.uuid && lhs.peerID == rhs.peerID
-  }
-
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(uuid)
-    hasher.combine(peerID)
-  }
-}
-
 final class SessionManager: NSObject {
-  
   static let shared = SessionManager()
   
   var peerID: MCPeerID!
@@ -35,38 +15,21 @@ final class SessionManager: NSObject {
   var advertiser: MCNearbyServiceAdvertiser?
   var browser: MCBrowserViewController?
   var localUserInfo: UserInfo?
-  var projectName: String?
   var isHost: Bool = false
+  var projectName: String?
   var feedbackCompletionCount: Int = 0
-  
-  var connectedUserInfos: [UserInfo] = []
-  var myFeedbackDatas: [SkillSet] = []
-  var resultData: SkillSet = SkillSet(categories: [communication, selfDevelopment, problemSolving, teamwork, leadership])
+  private let serviceType = "feedbacksession"
   
   var onPeersChanged: (() -> Void)?
   var onDataReceived: ((Data, MCPeerID) -> Void)?
   var onPushDataReceived: (() -> Void)?
   
-  var localUserUUID: String {
-    if let uuid = UserDefaults.standard.string(forKey: "localUserUUID") {
-      return uuid
-    } else {
-      let newUUID = UUID().uuidString
-      UserDefaults.standard.set(newUUID, forKey: "localUserUUID")
-      return newUUID
-    }
-  }
-  
-  private let serviceType = "feedbacksession"
-  
-  private override init() {
-    super.init()
-  }
+  private override init() { super.init() }
   
   func setLocalUserInfo(name: String, role: String) {
     let peerID = MCPeerID(displayName: name)
     localUserInfo = UserInfo(
-      uuid: localUserUUID,
+      uuid: UUID().uuidString,
       peerID: peerID,
       role: role
     )
@@ -92,7 +55,7 @@ final class SessionManager: NSObject {
     if isHost {
       setAdvertiser()
       if let localUserInfo = localUserInfo {
-        connectedUserInfos.append(localUserInfo)
+        PeerInfoManager.shared.connectedUserInfos.append(localUserInfo)
       }
     } else {
       setBrowser(delegate: delegate)
@@ -107,7 +70,6 @@ final class SessionManager: NSObject {
     } else {
       browser?.dismiss(animated: true, completion: nil)
     }
-    
     print("세션 종료됨")
   }
   
@@ -118,34 +80,24 @@ final class SessionManager: NSObject {
   }
   
   private func setBrowser(delegate: MCBrowserViewControllerDelegate?) {
-    browser = MCBrowserViewController(serviceType: serviceType, session: session)
+    browser = MCBrowserViewController(
+      serviceType: serviceType,
+      session: session
+    )
     browser?.delegate = delegate
   }
   
-  func sendData(_ data: Data, message: String, to: [MCPeerID]) {
-    guard !session.connectedPeers.isEmpty else { return }
-    
-    let messageData = MessageData(message: message, data: data)
-    
-    do {
-      let encodedMessageData = try JSONEncoder().encode(messageData)
-      
-      try session.send(encodedMessageData, toPeers: to, with: .reliable)
-    } catch {
-      print("데이터 전송 실패: \(error.localizedDescription)")
-    }
-  }
-  
   func checkAllFeedbackCompleted() {
-    if feedbackCompletionCount == connectedUserInfos.count {
+    if feedbackCompletionCount == PeerInfoManager.shared.connectedUserInfos.count {
       DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
         if let pushResultData = try? JSONEncoder().encode(self.localUserInfo) {
-          self.sendData(pushResultData, message: "showResults", to: self.session.connectedPeers)
+          SessionDataSender.shared.sendData(
+            pushResultData,
+            message: "showResults",
+            to: self.session.connectedPeers
+          )
         }
-        let resultVC = ResultViewController()
-        if let navigationController = UIApplication.shared.windows.first?.rootViewController as? UINavigationController {
-          navigationController.pushViewController(resultVC, animated: true)
-        }
+        self.onPushDataReceived?()
       }
     }
   }
@@ -160,105 +112,46 @@ extension SessionManager: MCSessionDelegate {
   ) {
     switch state {
     case .connected:
-      if !SessionManager.shared.isHost {
-        if let hostPeerID = SessionManager.shared.session.connectedPeers.first,
-           let localUserInfoData = try? JSONEncoder().encode(localUserInfo) {
-          sendData(
+      print("연결됨: \(peerID.displayName)")
+      if !isHost, let localUserInfoData = try? JSONEncoder().encode(localUserInfo) {
+        if let hostPeerID = session.connectedPeers.first {
+          SessionDataSender.shared.sendData(
             localUserInfoData,
             message: "localUserInfo",
             to: [hostPeerID]
           )
-          print("Peer가 Host에게 LocalUserInfo 전송")
+          print(
+            "Peer가 Host에게 LocalUserInfo 전송"
+          )
         }
       }
+      
     case .connecting:
       print("연결 중: \(peerID.displayName)")
+      
     case .notConnected:
       print("연결 끊김: \(peerID.displayName)")
+      
     @unknown default:
       fatalError("알 수 없는 상태")
     }
-    
+    DispatchQueue.main.async { self.onPeersChanged?() }
+  }
+  
+  func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
     DispatchQueue.main.async {
-      self.onPeersChanged?()
+      self.onDataReceived?(data, peerID)
     }
+    SessionDataReceiver.shared.processReceivedData(data, from: peerID)
   }
   
-  func session(
-    _ session: MCSession,
-    didReceive data: Data,
-    fromPeer departureID: MCPeerID
-  ) {
-    DispatchQueue.main.async {
-      self.onDataReceived?(data, departureID)
-    }
-    
-    if let receivedMessageData = try? JSONDecoder().decode(MessageData.self, from: data) {
-      print("수신한 메시지: \(receivedMessageData.message)")
-      
-      switch receivedMessageData.message {
-        
-      case "localUserInfo":
-        if let receivedUserInfo = try? JSONDecoder().decode(
-          UserInfo.self,
-          from: receivedMessageData.data
-        ) {
-          SessionManager.shared.connectedUserInfos.append(receivedUserInfo)
-          print("Peer가 Session에 입장, Host가 Peer의 LocalUserInfo를 수신")
-        }
-        
-      case "startFeedback":
-        if let receivedUserInfoData = try? JSONDecoder().decode(
-          [UserInfo].self,
-          from: receivedMessageData.data
-        ) {
-          self.connectedUserInfos = receivedUserInfoData
-          DispatchQueue.main.async {
-            self.onPushDataReceived?()
-          }
-        }
-        
-      case "sendFeedback":
-        if let receivedFeedbackData = try? JSONDecoder().decode(SkillSet.self, from: receivedMessageData.data) {
-          self.myFeedbackDatas.append(receivedFeedbackData)
-          
-          resultData = SkillSet(categories: [communication, selfDevelopment, problemSolving, teamwork, leadership])
-          
-          for feedbackData in myFeedbackDatas {
-            for (categoryIndex, category) in feedbackData.categories.enumerated() {
-              for (traitIndex, trait) in category.traits.enumerated() {
-                resultData.categories[categoryIndex].traits[traitIndex].count += trait.count
-              }
-            }
-          }
-        }
-        
-      case "feedbackCompleted":
-        feedbackCompletionCount += 1
-        print("피드백 완료 인원 추가")
-        if isHost {
-          checkAllFeedbackCompleted()
-        }
-        
-      case "showResults":
-        DispatchQueue.main.async {
-          self.onPushDataReceived?()
-        }
-        
-      default:
-        print("알 수 없는 메시지: \(receivedMessageData.message)")
-      }
-    }
-  }
-  
-  
-  func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
-  }
+  func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {}
   
   func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {}
   
   func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {}
 }
+
 // MARK: - MCBrowserViewControllerDelegate
 extension SessionManager: MCBrowserViewControllerDelegate {
   func browserViewControllerDidFinish(_ browserViewController: MCBrowserViewController) {
@@ -273,8 +166,6 @@ extension SessionManager: MCBrowserViewControllerDelegate {
 // MARK: - MCNearbyServiceAdvertiserDelegate
 extension SessionManager: MCNearbyServiceAdvertiserDelegate {
   func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-    // 피어의 초대 처리
-    invitationHandler(true, session) // 자동 수락 예시
+    invitationHandler(true, session)
   }
 }
-

--- a/feedback-iOS/feedback-iOS/Presentation/Model/SessionManager.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/SessionManager.swift
@@ -17,8 +17,13 @@ final class SessionManager: NSObject {
   var localUserInfo: UserInfo?
   var isHost: Bool = false
   var projectName: String?
-  var feedbackCompletionCount: Int = 0
   private let serviceType = "feedbacksession"
+  
+  var feedbackCompletionCount: Int = 0 {
+    didSet {
+      checkAllFeedbackCompleted()
+    }
+  }
   
   var onPeersChanged: (() -> Void)?
   var onDataReceived: ((Data, MCPeerID) -> Void)?
@@ -88,6 +93,7 @@ final class SessionManager: NSObject {
   }
   
   func checkAllFeedbackCompleted() {
+    print("\(feedbackCompletionCount)")
     if feedbackCompletionCount == PeerInfoManager.shared.connectedUserInfos.count {
       DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
         if let pushResultData = try? JSONEncoder().encode(self.localUserInfo) {
@@ -100,6 +106,22 @@ final class SessionManager: NSObject {
         self.onPushDataReceived?()
       }
     }
+  }
+  
+  func reset() {
+    stopSession()
+    peerID = nil
+    session = nil
+    advertiser = nil
+    browser = nil
+    localUserInfo = nil
+    isHost = false
+    projectName = nil
+    feedbackCompletionCount = 0
+    onPeersChanged = nil
+    onDataReceived = nil
+    onPushDataReceived = nil
+    print("SessionManager 초기화 완료")
   }
 }
 

--- a/feedback-iOS/feedback-iOS/Presentation/Model/UserInfo.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/UserInfo.swift
@@ -1,0 +1,21 @@
+//
+//  UserInfo.swift
+//  feedback-iOS
+//
+//  Created by Chandrala on 11/8/24.
+//
+
+import MultipeerConnectivity
+import UIKit
+
+struct UserInfo: Codable, Equatable, Hashable {
+  let uuid: String
+  let peerID: String
+  let role: String
+  
+  init(uuid: String, peerID: MCPeerID, role: String) {
+    self.uuid = uuid
+    self.peerID = peerID.displayName
+    self.role = role
+  }
+}

--- a/feedback-iOS/feedback-iOS/Presentation/Model/UserInfo.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/Model/UserInfo.swift
@@ -10,12 +10,33 @@ import UIKit
 
 struct UserInfo: Codable, Equatable, Hashable {
   let uuid: String
-  let peerID: String
+  let peerID: MCPeerID
   let role: String
   
   init(uuid: String, peerID: MCPeerID, role: String) {
     self.uuid = uuid
-    self.peerID = peerID.displayName
+    self.peerID = peerID
     self.role = role
+  }
+  
+  enum CodingKeys: String, CodingKey {
+    case uuid
+    case peerID
+    case role
+  }
+  
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(uuid, forKey: .uuid)
+    try container.encode(peerID.displayName, forKey: .peerID)
+    try container.encode(role, forKey: .role)
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    uuid = try container.decode(String.self, forKey: .uuid)
+    let peerIDString = try container.decode(String.self, forKey: .peerID)
+    peerID = MCPeerID(displayName: peerIDString)
+    role = try container.decode(String.self, forKey: .role)
   }
 }

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
@@ -160,7 +160,7 @@ class FeedbackDetailViewController: UIViewController {
           
           let selectedFeedbacksData = try JSONEncoder().encode(skill)
           
-          SessionManager.shared.sendData(selectedFeedbacksData, message: "sendFeedback", to: [targetPeerID])
+          SessionDataSender.shared.sendData(selectedFeedbacksData, message: "sendFeedback", to: [targetPeerID])
           
           onFeedbackCompleted?(selectedUserInfo.peerID)
         } else {

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
@@ -27,6 +27,8 @@ class FeedbackDetailViewController: UIViewController {
   var onFeedbackCompleted: ((String) -> Void)?
   
   override func viewDidLoad() {
+    
+    print("\(PeerInfoManager.shared.connectedUserInfos)")
     super.viewDidLoad()
     setStyle()
     setUI()
@@ -44,7 +46,7 @@ class FeedbackDetailViewController: UIViewController {
     }
     
     userImageView.do {
-      if let firstCharacter = selectedUserInfo?.peerID.first {
+      if let firstCharacter = selectedUserInfo?.peerID.displayName.first {
         $0.text = String(firstCharacter)
       }
       $0.font = UIFont.systemFont(ofSize: 32, weight: .bold)
@@ -55,7 +57,7 @@ class FeedbackDetailViewController: UIViewController {
     }
     
     userName.do {
-      $0.text = selectedUserInfo?.peerID
+      $0.text = selectedUserInfo?.peerID.displayName
       $0.font = UIFont.sfPro(.title2)
     }
     
@@ -71,7 +73,6 @@ class FeedbackDetailViewController: UIViewController {
       $0.action = #selector(doneButtonTapped)
       $0.isEnabled = false
     }
-    
   }
   
   private func setUI() {
@@ -156,13 +157,13 @@ class FeedbackDetailViewController: UIViewController {
     
     if let selectedUserInfo = selectedUserInfo {
       do {
-        if let targetPeerID = SessionManager.shared.session.connectedPeers.first(where: { $0.displayName == selectedUserInfo.peerID }) {
+        if let targetPeerID = SessionManager.shared.session.connectedPeers.first(where: { $0.displayName == selectedUserInfo.peerID.displayName }) {
           
           let selectedFeedbacksData = try JSONEncoder().encode(skill)
           
           SessionDataSender.shared.sendData(selectedFeedbacksData, message: "sendFeedback", to: [targetPeerID])
           
-          onFeedbackCompleted?(selectedUserInfo.peerID)
+          onFeedbackCompleted?(selectedUserInfo.peerID.displayName)
         } else {
           print("해당 피어를 찾을 수 없습니다.")
         }

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackViewController.swift
@@ -110,7 +110,7 @@ final class FeedbackViewController: UIViewController {
       } else {
         if let feedbackCompletedData = try? JSONEncoder().encode(SessionManager.shared.localUserInfo?.peerID) {
           if let hostPeerID = SessionManager.shared.session.connectedPeers.first {
-            SessionManager.shared.sendData(
+            SessionDataSender.shared.sendData(
               feedbackCompletedData,
               message: "feedbackCompleted",
               to: [hostPeerID]
@@ -132,12 +132,12 @@ final class FeedbackViewController: UIViewController {
 
 extension FeedbackViewController: UITableViewDelegate, UITableViewDataSource {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return SessionManager.shared.connectedUserInfos.count
+    return PeerInfoManager.shared.connectedUserInfos.count
   }
   
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(withIdentifier: FeedbackTableViewCell.identifier, for: indexPath)
-    let userInfo = SessionManager.shared.connectedUserInfos[indexPath.row]
+    let userInfo = PeerInfoManager.shared.connectedUserInfos[indexPath.row]
     cell.textLabel?.text = "\(userInfo.peerID)\n\(userInfo.role)"
     
     if userInfo.peerID == SessionManager.shared.peerID.displayName {
@@ -163,7 +163,7 @@ extension FeedbackViewController: UITableViewDelegate, UITableViewDataSource {
   }
   
   func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-    let selectedUserInfo = SessionManager.shared.connectedUserInfos[indexPath.row]
+    let selectedUserInfo = PeerInfoManager.shared.connectedUserInfos[indexPath.row]
     
     if selectedUserInfo.peerID == SessionManager.shared.localUserInfo?.peerID {
       return nil
@@ -172,7 +172,7 @@ extension FeedbackViewController: UITableViewDelegate, UITableViewDataSource {
   }
   
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    let selectedUserInfo = SessionManager.shared.connectedUserInfos[indexPath.row]
+    let selectedUserInfo = PeerInfoManager.shared.connectedUserInfos[indexPath.row]
     
     let detailVC = FeedbackDetailViewController()
     let modalDetailVC = UINavigationController(rootViewController: detailVC)

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackViewController.swift
@@ -25,8 +25,6 @@ final class FeedbackViewController: UIViewController {
     setAutolayout()
     setTableView()
     updateTableViewHeight()
-    
-    print(SessionManager.shared.receivedUserInfos)
   }
   
   func setStyle() {
@@ -134,12 +132,12 @@ final class FeedbackViewController: UIViewController {
 
 extension FeedbackViewController: UITableViewDelegate, UITableViewDataSource {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return SessionManager.shared.receivedUserInfos.count
+    return SessionManager.shared.connectedUserInfos.count
   }
   
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     let cell = tableView.dequeueReusableCell(withIdentifier: FeedbackTableViewCell.identifier, for: indexPath)
-    let userInfo = SessionManager.shared.receivedUserInfos[indexPath.row]
+    let userInfo = SessionManager.shared.connectedUserInfos[indexPath.row]
     cell.textLabel?.text = "\(userInfo.peerID)\n\(userInfo.role)"
     
     if userInfo.peerID == SessionManager.shared.peerID.displayName {
@@ -165,7 +163,7 @@ extension FeedbackViewController: UITableViewDelegate, UITableViewDataSource {
   }
   
   func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-    let selectedUserInfo = SessionManager.shared.receivedUserInfos[indexPath.row]
+    let selectedUserInfo = SessionManager.shared.connectedUserInfos[indexPath.row]
     
     if selectedUserInfo.peerID == SessionManager.shared.localUserInfo?.peerID {
       return nil
@@ -174,7 +172,7 @@ extension FeedbackViewController: UITableViewDelegate, UITableViewDataSource {
   }
   
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    let selectedUserInfo = SessionManager.shared.receivedUserInfos[indexPath.row]
+    let selectedUserInfo = SessionManager.shared.connectedUserInfos[indexPath.row]
     
     let detailVC = FeedbackDetailViewController()
     let modalDetailVC = UINavigationController(rootViewController: detailVC)

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/HomeViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/HomeViewController.swift
@@ -332,11 +332,14 @@ final class HomeViewController: UIViewController {
       let userName = self.userNameTextField.text ?? ""
       let userRole = self.descriptionTextField.text ?? ""
       let projectName = alertController.textFields?.first?.text ?? ""
+      
+      /// Host의 로컬유저 정보 저장
       SessionManager.shared.setLocalUserInfo(
         name: userName,
         role: userRole
       )
       
+      /// SetSession
       if !projectName.isEmpty {
         SessionManager.shared.setSession(
           isHost: true,

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/HomeViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/HomeViewController.swift
@@ -373,11 +373,10 @@ final class HomeViewController: UIViewController {
       displayName: userName,
       delegate: self
     )
-        
-        if let browser = SessionManager.shared.browser {
-          present(browser, animated: true)
-        }
-      }
+    if let browser = SessionManager.shared.browser {
+      present(browser, animated: true)
+    }
+  }
   
   private func setupNotifications() {
     NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/LobbyViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/LobbyViewController.swift
@@ -125,19 +125,16 @@ class LobbyViewController: UIViewController {
   }
   
   @objc func startFeedbackButtonTapped() {
-    let uniqueUserInfos = NSOrderedSet(array: SessionManager.shared.receivedUserInfos).array as! [UserInfo]
-    SessionManager.shared.receivedUserInfos = uniqueUserInfos
-    do {
-      let allUserInfoData = try JSONEncoder().encode(uniqueUserInfos)
+    /// 연결된 피어에게 모든 피어의 PeerID 공유
+    if let connectedUserInfoData = try? JSONEncoder().encode(SessionManager.shared.connectedUserInfos) {
       SessionManager.shared.sendData(
-        allUserInfoData,
+        connectedUserInfoData,
         message: "startFeedback",
         to: SessionManager.shared.session.connectedPeers
       )
-    } catch {
-      print("\(error.localizedDescription)")
     }
     
+    ///
     let feedbackVC = FeedbackViewController()
     self.navigationController?.pushViewController(feedbackVC, animated: true)
   }

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/LobbyViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/LobbyViewController.swift
@@ -126,8 +126,8 @@ class LobbyViewController: UIViewController {
   
   @objc func startFeedbackButtonTapped() {
     /// 연결된 피어에게 모든 피어의 PeerID 공유
-    if let connectedUserInfoData = try? JSONEncoder().encode(SessionManager.shared.connectedUserInfos) {
-      SessionManager.shared.sendData(
+    if let connectedUserInfoData = try? JSONEncoder().encode(PeerInfoManager.shared.connectedUserInfos) {
+      SessionDataSender.shared.sendData(
         connectedUserInfoData,
         message: "startFeedback",
         to: SessionManager.shared.session.connectedPeers

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/LobbyViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/LobbyViewController.swift
@@ -22,6 +22,7 @@ class LobbyViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
+    sendUserInfoData()
     setStyle()
     setUI()
     setAutoLayout()
@@ -125,18 +126,51 @@ class LobbyViewController: UIViewController {
   }
   
   @objc func startFeedbackButtonTapped() {
-    /// 연결된 피어에게 모든 피어의 PeerID 공유
-    if let connectedUserInfoData = try? JSONEncoder().encode(PeerInfoManager.shared.connectedUserInfos) {
-      SessionDataSender.shared.sendData(
-        connectedUserInfoData,
-        message: "startFeedback",
-        to: SessionManager.shared.session.connectedPeers
-      )
+    showLoadingIndicator()
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+      if let connectedUserInfoData = try? JSONEncoder().encode(PeerInfoManager.shared.connectedUserInfos) {
+        SessionDataSender.shared.sendData(
+          connectedUserInfoData,
+          message: "startFeedback",
+          to: SessionManager.shared.session.connectedPeers
+        )
+      }
+      let feedbackVC = FeedbackViewController()
+      self.navigationController?.pushViewController(feedbackVC, animated: true)
     }
+  }
+  
+  private func showLoadingIndicator() {
+    guard let window = UIApplication.shared.windows.first else { return }
+    let overlayView = UIView(frame: window.bounds)
     
-    ///
-    let feedbackVC = FeedbackViewController()
-    self.navigationController?.pushViewController(feedbackVC, animated: true)
+    overlayView.backgroundColor = UIColor(white: 0, alpha: 0.3)
+    let activityIndicator = UIActivityIndicatorView(style: .large)
+    activityIndicator.center = overlayView.center
+    activityIndicator.startAnimating()
+    
+    overlayView.addSubview(activityIndicator)
+    view.addSubview(overlayView)
+    
+    view.isUserInteractionEnabled = false
+  }
+  
+  private func sendUserInfoData() {
+    let delay = Double(abs(SessionManager.shared.localUserInfo?.uuid.hashValue ?? 0) % 5000) / 1000.0
+    print(delay)
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+      if !SessionManager.shared.isHost, let localUserInfoData = try? JSONEncoder().encode(SessionManager.shared.localUserInfo) {
+        if let hostPeerID = SessionManager.shared.session.connectedPeers.first {
+          SessionDataSender.shared.sendData(
+            localUserInfoData,
+            message: "localUserInfo",
+            to: [hostPeerID]
+          )
+          print("Peer가 Host에게 LocalUserInfo 전송")
+        }
+      }
+    }
   }
 }
 

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/ResultViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/ResultViewController.swift
@@ -14,7 +14,7 @@ final class ResultViewController: UIViewController {
   let containerView = UIView()
   let graphTitleLabel = UILabel()
   let mostReceivedSkillLabel = UILabel()
-  var hitmapView = HeatmapView(frame: .zero, skillSet: SessionManager.shared.resultData)
+  var hitmapView = HeatmapView(frame: .zero, skillSet: PeerInfoManager.shared.resultData)
   let containerViewFooter = UILabel()
   var isCompleted: Bool = false
   let doneButton = UIButton()
@@ -26,7 +26,7 @@ final class ResultViewController: UIViewController {
     setUI()
     setAutoLayout()
     
-    if let mostSelected = findMostSelectedTraitAndCategory(in: SessionManager.shared.resultData) {
+    if let mostSelected = findMostSelectedTraitAndCategory(in: PeerInfoManager.shared.resultData) {
       mostReceivedSkillLabel.text = "\(mostSelected.trait) \(mostSelected.category) 􁾪"
     } else {
       mostReceivedSkillLabel.text = "데이터가 없습니다."

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/ResultViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/ResultViewController.swift
@@ -135,7 +135,8 @@ final class ResultViewController: UIViewController {
     )
     
     let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
-      SessionManager.shared.stopSession()
+      SessionManager.shared.reset()
+      PeerInfoManager.shared.reset()
       self.navigationController?.popToRootViewController(animated: true)
     }
     

--- a/feedback-iOS/feedback-iOS/Source/Component/HeatmapView.swift
+++ b/feedback-iOS/feedback-iOS/Source/Component/HeatmapView.swift
@@ -141,7 +141,7 @@ class HeatmapCell: UICollectionViewCell {
     if selectionCount == 0 {
       backgroundColor = .systemGray5
     } else {
-      let intensity = CGFloat(selectionCount) / CGFloat(SessionManager.shared.receivedUserInfos.count)
+      let intensity = CGFloat(selectionCount) / CGFloat(SessionManager.shared.connectedUserInfos.count)
       let color = UIColor(red: 0.0, green: 122.0 / 255.0, blue: 1.0, alpha: intensity)
       backgroundColor = color
     }

--- a/feedback-iOS/feedback-iOS/Source/Component/HeatmapView.swift
+++ b/feedback-iOS/feedback-iOS/Source/Component/HeatmapView.swift
@@ -141,7 +141,7 @@ class HeatmapCell: UICollectionViewCell {
     if selectionCount == 0 {
       backgroundColor = .systemGray5
     } else {
-      let intensity = CGFloat(selectionCount) / CGFloat(SessionManager.shared.connectedUserInfos.count)
+      let intensity = CGFloat(selectionCount) / CGFloat(PeerInfoManager.shared.connectedUserInfos.count)
       let color = UIColor(red: 0.0, green: 122.0 / 255.0, blue: 1.0, alpha: intensity)
       backgroundColor = color
     }


### PR DESCRIPTION
## PR 내용
MultipeerConnectivity에서 Session과 연관된 로직을 리팩토링했습니다.

## PR 설명
1. 호스트와 피어 간 데이터 `ConnectedUserInfo`동기화 방식을 수정했습니다
피어가 세션 연결(**삭제**) > 호스트의 UserInfo 피어에게 전달(**삭제**) > 피어가 UserInfo 호스트에게 전달 > 피드백 시작할 때 호스트가 모든 참가자에게 ConnectedPeers UserInfo 전달
2. SessionManager 책임 분리 작업을 했습니다.
- `SessionManager`: SessionDelegate, Session 생성 함수
- `PeerInfoManager`: Session에 연결된 Peer 관리
- `SessionDataReceiver`, `SessionDataSender`: Peer간 데이터 주고받는 함수
3. 피드백 완료여부 로직을 개선했습니다.
피드백 완료 변수에 didSet을 설정해서 값이 변할 때 마다 결과창으로 넘어가는 함수 호출

++ 컨벤션, 불필요 코드 제거 리팩토링은 다음 브랜치에서 작업하겠습니다아
resolve #31 
