### PR TITLE
[Refactor] FeedbackSelectionComponent 리팩토링

### DIFF
--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
@@ -143,7 +143,7 @@ class FeedbackDetailViewController: UIViewController {
   func updateDoneButtonState() {
     for subview in contentView.subviews {
       if let feedbackComponent = subview as? FeedbackSelectionComponent {
-        if feedbackComponent.selectedTraitsTitles.count != feedbackComponent.maxSelectableTraits {
+        if feedbackComponent.selectedTraitTitles.count != feedbackComponent.maxTraitSelectionCount {
           doneButton.isEnabled = false
           return
         }

--- a/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
+++ b/feedback-iOS/feedback-iOS/Presentation/ViewController/FeedbackDetailViewController.swift
@@ -1,5 +1,5 @@
 //
-//  TestViewController.swift
+//  FeedbackDetailViewController.swift
 //  feedback-iOS
 //
 //  Created by 이빈 on 10/16/24.
@@ -84,7 +84,7 @@ class FeedbackDetailViewController: UIViewController {
     view.addSubview(scrollView)
     
     for (index, category) in skill.categories.enumerated() {
-      let feedbackComponent = FeedbackSelectionComponent(name: category.name, traits: category.traits)
+      let feedbackComponent = FeedbackSelectionComponent(categoryName: category.name, traits: category.traits)
       feedbackComponent.parentViewController = self
       contentView.addSubview(feedbackComponent)
       
@@ -132,7 +132,7 @@ class FeedbackDetailViewController: UIViewController {
     }
   }
   
-  func updateTraitSelection(categoryIndex: Int, traitIndex: Int, increase: Bool) {
+  func updateSelectedTraitCount(categoryIndex: Int, traitIndex: Int, increase: Bool) {
     if increase {
       skill.categories[categoryIndex].traits[traitIndex].count += 1
     } else {
@@ -173,3 +173,4 @@ class FeedbackDetailViewController: UIViewController {
     dismiss(animated: true, completion: nil)
   }
 }
+

--- a/feedback-iOS/feedback-iOS/Source/Component/FeedbackSelectionComponent.swift
+++ b/feedback-iOS/feedback-iOS/Source/Component/FeedbackSelectionComponent.swift
@@ -5,9 +5,9 @@
 //  Created by 이빈 on 10/16/24.
 //
 
-import UIKit
 import SnapKit
 import Then
+import UIKit
 
 final class FeedbackSelectionComponent: UIView {
   
@@ -19,14 +19,13 @@ final class FeedbackSelectionComponent: UIView {
   // MARK: - Properties
   private(set) var selectedTraitTitles: [String] = []
   let maxTraitSelectionCount = 2
-  private var name: String
+  private var categoryName: String
   private var traits: [Trait]
   weak var parentViewController: FeedbackDetailViewController?
   
-  
   // MARK: - Initializer
-  init(name: String, traits: [Trait]) {
-    self.name = name
+  init(categoryName: String, traits: [Trait]) {
+    self.categoryName = categoryName
     self.traits = traits
     super.init(frame: .zero)
     
@@ -41,12 +40,13 @@ final class FeedbackSelectionComponent: UIView {
   
   // MARK: - UI Setup
   private func setStyle() {
+    
     titleLabel.do {
-      $0.text = name
+      $0.text = categoryName
       $0.font = UIFont.sfPro(.header)
       $0.textColor = .gray
     }
-    
+
     buttonCollectionView.do {
       let layout = LeftAlignedCollectionViewFlowLayout()
       layout.scrollDirection = .vertical
@@ -54,7 +54,7 @@ final class FeedbackSelectionComponent: UIView {
       layout.minimumInteritemSpacing = 7
       layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
       layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
-      $0.setCollectionViewLayout(layout, animated: false)
+      $0.collectionViewLayout = layout
       $0.backgroundColor = .clear
     }
     
@@ -63,6 +63,7 @@ final class FeedbackSelectionComponent: UIView {
       $0.font = UIFont.sfPro(.footer)
       $0.textColor = .gray
     }
+    
   }
   
   private func setUI() {
@@ -74,10 +75,7 @@ final class FeedbackSelectionComponent: UIView {
     
     buttonCollectionView.delegate = self
     buttonCollectionView.dataSource = self
-    buttonCollectionView.register(
-      TraitButtonCell.self,
-      forCellWithReuseIdentifier: TraitButtonCell.reuseIdentifier
-    )
+    buttonCollectionView.register(TraitButtonCell.self, forCellWithReuseIdentifier: TraitButtonCell.reuseIdentifier)
   }
   
   private func setAutoLayout() {
@@ -99,7 +97,6 @@ final class FeedbackSelectionComponent: UIView {
     }
   }
   
-  //?
   override func layoutSubviews() {
     super.layoutSubviews()
     updateCollectionViewHeight()
@@ -108,60 +105,9 @@ final class FeedbackSelectionComponent: UIView {
   private func updateCollectionViewHeight() {
     let height = buttonCollectionView.collectionViewLayout.collectionViewContentSize.height
     buttonCollectionView.snp.updateConstraints {
-      $0.height.equalTo(height)  // 자동으로 컬렉션 뷰의 높이를 조정
+      $0.height.equalTo(height)
     }
   }
-}
-
-
-extension FeedbackSelectionComponent: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-  
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return traits.count
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard indexPath.item < traits.count else {
-      return UICollectionViewCell()
-    }
-    
-    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TraitCell", for: indexPath) as! TraitButtonCell
-    let trait = traits[indexPath.item]
-    
-    let isSelected = selectedTraitTitles.contains(trait.name)
-    cell.configure(with: trait.name, isSelected: isSelected)
-    
-    return cell
-  }
-  
-  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    // 선택한 Trait의 인덱스 정보
-    let categoryIndex = parentViewController?.skill.categories.firstIndex(where: { $0.name == self.name }) ?? 0
-    let traitIndex = indexPath.item
-    
-    // 선택한 항목을 추가/삭제
-    let trait = traits[traitIndex]
-    if let index = selectedTraitTitles.firstIndex(of: trait.name) {
-      selectedTraitTitles.remove(at: index)
-      parentViewController?.updateTraitSelection(categoryIndex: categoryIndex, traitIndex: traitIndex, increase: false)
-      
-    } else {
-      if selectedTraitTitles.count >= 2 {
-        return
-      }
-      selectedTraitTitles.append(trait.name)
-      parentViewController?.updateTraitSelection(categoryIndex: categoryIndex, traitIndex: traitIndex, increase: true)
-    }
-    
-    // UI 갱신
-    collectionView.reloadItems(at: [indexPath])
-    
-    updateFooterLabel()
-    
-    // 완료 버튼 상태 업데이트
-    parentViewController?.updateDoneButtonState()
-  }
-  
   
   private func updateFooterLabel() {
     if selectedTraitTitles.count == maxTraitSelectionCount {
@@ -172,6 +118,58 @@ extension FeedbackSelectionComponent: UICollectionViewDelegate, UICollectionView
   }
 }
 
+// MARK: - Extension UICollectionView
+extension FeedbackSelectionComponent: UICollectionViewDataSource, UICollectionViewDelegate {
+  
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return traits.count
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard indexPath.item < traits.count else {
+      return UICollectionViewCell()
+    }
+    
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TraitButtonCell.reuseIdentifier, for: indexPath) as! TraitButtonCell
+    let trait = traits[indexPath.item]
+    let isSelected = selectedTraitTitles.contains(trait.name)
+    cell.configure(with: trait.name, isSelected: isSelected)
+    return cell
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    // 선택한 Trait의 인덱스 정보
+    guard let categoryIndex = parentViewController?.skill.categories.firstIndex(where: { $0.name == self.categoryName }) else {
+      print("Invalid category index for \(self.categoryName)")
+      return
+    }
+    let traitIndex = indexPath.item
+    let trait = traits[traitIndex]
+    
+    // 삭제
+    if let index = selectedTraitTitles.firstIndex(of: trait.name) {
+      selectedTraitTitles.remove(at: index)
+      parentViewController?.updateSelectedTraitCount(categoryIndex: categoryIndex, traitIndex: traitIndex, increase: false)
+    } else {
+      // 최대 선택 개수 확인
+      guard selectedTraitTitles.count < maxTraitSelectionCount else {
+        print("Max selectable traits reached")
+        return
+      }
+      // 추가
+      selectedTraitTitles.append(trait.name)
+      parentViewController?.updateSelectedTraitCount(categoryIndex: categoryIndex, traitIndex: traitIndex, increase: true)
+    }
+    
+    // UI 업데이트
+    collectionView.reloadItems(at: [indexPath])
+    updateFooterLabel()
+    parentViewController?.updateDoneButtonState()
+  }
+
+}
+
+// MARK: - UICollectionView Flow Layout
 class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
   
   override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
@@ -185,11 +183,8 @@ class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
         if layoutAttribute.frame.origin.y >= maxY {
           leftMargin = sectionInset.left
         }
-        
         layoutAttribute.frame.origin.x = leftMargin
-        
         leftMargin += layoutAttribute.frame.width + minimumInteritemSpacing
-      
         maxY = max(layoutAttribute.frame.maxY, maxY)
       }
     }
@@ -197,47 +192,42 @@ class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
   }
 }
 
-
+// MARK: - UICollectionViewCell
 final class TraitButtonCell: UICollectionViewCell {
+  static let reuseIdentifier = "TraitButtonCell"
   
   private let button: UIButton = {
     let button = UIButton()
     button.titleLabel?.font = UIFont.sfPro(.subheadline)
-    button.backgroundColor = UIColor(red: 120.0 / 255.0, green: 120.0 / 255.0, blue: 128.0 / 255.0, alpha: 0.12)
-    button.configuration?.buttonSize = .medium
-    button.configuration?.contentInsets = .init(top: 10, leading: 14, bottom: 10, trailing: 14)
-    button.setTitleColor(UIColor(red: 60.0 / 255.0, green: 60.0 / 255.0, blue: 67.0 / 255.0, alpha: 0.3), for: .normal)
     button.layer.cornerRadius = 15
     button.clipsToBounds = true
-    button.isUserInteractionEnabled = false  // 버튼이 직접 터치 이벤트를 처리하지 않도록 설정
+    button.isUserInteractionEnabled = false
     return button
   }()
   
   override init(frame: CGRect) {
     super.init(frame: frame)
     contentView.addSubview(button)
-    button.snp.makeConstraints {
-      $0.edges.equalToSuperview()
-    }
+    button.snp.makeConstraints { $0.edges.equalToSuperview() }
   }
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
   
-  private func updateButtonAppearance(isSelected: Bool) {
-    if isSelected {
-      button.backgroundColor = UIColor(red: 0.0 / 255.0, green: 122.0 / 255.0, blue: 255.0 / 255.0, alpha: 0.15)
-      button.setTitleColor(UIColor(red: 0.0 / 255.0, green: 122.0 / 255.0, blue: 255.0 / 255.0, alpha: 1.0), for: .normal)
-    } else {
-      button.backgroundColor = UIColor(red: 120.0 / 255.0, green: 120.0 / 255.0, blue: 128.0 / 255.0, alpha: 0.12)
-      button.setTitleColor(UIColor(red: 60.0 / 255.0, green: 60.0 / 255.0, blue: 67.0 / 255.0, alpha: 0.3), for: .normal)
-    }
-  }
-  
   func configure(with title: String, isSelected: Bool) {
     let trimmedTitle = title.components(separatedBy: " (").first ?? title
     button.setTitle("   " + trimmedTitle + "   ", for: .normal)
     updateButtonAppearance(isSelected: isSelected)
+  }
+  
+  private func updateButtonAppearance(isSelected: Bool) {
+    button.backgroundColor = isSelected
+      ? UIColor.systemBlue.withAlphaComponent(0.15)
+      : UIColor.systemGray3.withAlphaComponent(0.12)
+    
+    button.setTitleColor(isSelected
+      ? UIColor.systemBlue
+      : UIColor.systemGray2, for: .normal)
   }
 }

--- a/feedback-iOS/feedback-iOS/Source/Component/FeedbackSelectionComponent.swift
+++ b/feedback-iOS/feedback-iOS/Source/Component/FeedbackSelectionComponent.swift
@@ -224,7 +224,7 @@ final class TraitButtonCell: UICollectionViewCell {
   private func updateButtonAppearance(isSelected: Bool) {
     button.backgroundColor = isSelected
       ? UIColor.systemBlue.withAlphaComponent(0.15)
-      : UIColor.systemGray3.withAlphaComponent(0.12)
+      : UIColor.systemGray2.withAlphaComponent(0.12)
     
     button.setTitleColor(isSelected
       ? UIColor.systemBlue

--- a/feedback-iOS/feedback-iOS/Source/Component/FeedbackSelectionComponent.swift
+++ b/feedback-iOS/feedback-iOS/Source/Component/FeedbackSelectionComponent.swift
@@ -6,34 +6,25 @@
 //
 
 import UIKit
-
 import SnapKit
 import Then
 
 final class FeedbackSelectionComponent: UIView {
   
+  // MARK: - Components
   let titleLabel = UILabel()
-  
-  let buttonCollectionView: UICollectionView = {
-    let layout = LeftAlignedCollectionViewFlowLayout()
-    layout.scrollDirection = .vertical
-    layout.minimumLineSpacing = 8
-    layout.minimumInteritemSpacing = 7
-    layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-    layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
-    return UICollectionView(frame: .zero, collectionViewLayout: layout)
-  }()
-  
+  let buttonCollectionView = UICollectionView(frame: .zero, collectionViewLayout: LeftAlignedCollectionViewFlowLayout())
   let footerLabel = UILabel()
   
-  private(set) var selectedTraitsTitles: [String] = []
-  let maxSelectableTraits = 2
-  
+  // MARK: - Properties
+  private(set) var selectedTraitTitles: [String] = []
+  let maxTraitSelectionCount = 2
   private var name: String
   private var traits: [Trait]
-  
   weak var parentViewController: FeedbackDetailViewController?
   
+  
+  // MARK: - Initializer
   init(name: String, traits: [Trait]) {
     self.name = name
     self.traits = traits
@@ -42,38 +33,51 @@ final class FeedbackSelectionComponent: UIView {
     setStyle()
     setUI()
     setAutoLayout()
-    
-    buttonCollectionView.delegate = self
-    buttonCollectionView.dataSource = self
-    buttonCollectionView.register(TraitButtonCell.self, forCellWithReuseIdentifier: "TraitCell")
   }
   
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
   
+  // MARK: - UI Setup
   private func setStyle() {
-    
     titleLabel.do {
-      $0.text = "\(name)"
+      $0.text = name
       $0.font = UIFont.sfPro(.header)
       $0.textColor = .gray
     }
-
+    
     buttonCollectionView.do {
+      let layout = LeftAlignedCollectionViewFlowLayout()
+      layout.scrollDirection = .vertical
+      layout.minimumLineSpacing = 8
+      layout.minimumInteritemSpacing = 7
+      layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+      layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+      $0.setCollectionViewLayout(layout, animated: false)
       $0.backgroundColor = .clear
     }
     
     footerLabel.do {
-      $0.text = "Data Collecting (0/2)"
+      $0.text = "Data Collecting (0/\(maxTraitSelectionCount))"
       $0.font = UIFont.sfPro(.footer)
       $0.textColor = .gray
     }
-    
   }
   
   private func setUI() {
-    self.addSubviews(titleLabel, buttonCollectionView, footerLabel)
+    self.addSubviews(
+      titleLabel,
+      buttonCollectionView,
+      footerLabel
+    )
+    
+    buttonCollectionView.delegate = self
+    buttonCollectionView.dataSource = self
+    buttonCollectionView.register(
+      TraitButtonCell.self,
+      forCellWithReuseIdentifier: TraitButtonCell.reuseIdentifier
+    )
   }
   
   private func setAutoLayout() {
@@ -90,11 +94,12 @@ final class FeedbackSelectionComponent: UIView {
     
     footerLabel.snp.makeConstraints {
       $0.top.equalTo(buttonCollectionView.snp.bottom).offset(12)
+      $0.bottom.equalToSuperview()
       $0.leading.equalToSuperview()
-      $0.bottom.equalToSuperview()  // 푸터 라벨이 컴포넌트의 끝
     }
   }
   
+  //?
   override func layoutSubviews() {
     super.layoutSubviews()
     updateCollectionViewHeight()
@@ -123,7 +128,7 @@ extension FeedbackSelectionComponent: UICollectionViewDelegate, UICollectionView
     let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TraitCell", for: indexPath) as! TraitButtonCell
     let trait = traits[indexPath.item]
     
-    let isSelected = selectedTraitsTitles.contains(trait.name)
+    let isSelected = selectedTraitTitles.contains(trait.name)
     cell.configure(with: trait.name, isSelected: isSelected)
     
     return cell
@@ -136,15 +141,15 @@ extension FeedbackSelectionComponent: UICollectionViewDelegate, UICollectionView
     
     // 선택한 항목을 추가/삭제
     let trait = traits[traitIndex]
-    if let index = selectedTraitsTitles.firstIndex(of: trait.name) {
-      selectedTraitsTitles.remove(at: index)
+    if let index = selectedTraitTitles.firstIndex(of: trait.name) {
+      selectedTraitTitles.remove(at: index)
       parentViewController?.updateTraitSelection(categoryIndex: categoryIndex, traitIndex: traitIndex, increase: false)
       
     } else {
-      if selectedTraitsTitles.count >= 2 {
+      if selectedTraitTitles.count >= 2 {
         return
       }
-      selectedTraitsTitles.append(trait.name)
+      selectedTraitTitles.append(trait.name)
       parentViewController?.updateTraitSelection(categoryIndex: categoryIndex, traitIndex: traitIndex, increase: true)
     }
     
@@ -159,10 +164,10 @@ extension FeedbackSelectionComponent: UICollectionViewDelegate, UICollectionView
   
   
   private func updateFooterLabel() {
-    if selectedTraitsTitles.count == maxSelectableTraits {
-      footerLabel.text = "􀇻 All Data Collected (\(selectedTraitsTitles.count)/\(maxSelectableTraits))"
+    if selectedTraitTitles.count == maxTraitSelectionCount {
+      footerLabel.text = "􀇻 All Data Collected (\(selectedTraitTitles.count)/\(maxTraitSelectionCount))"
     } else {
-      footerLabel.text = "Data Collecting (\(selectedTraitsTitles.count)/\(maxSelectableTraits))"
+      footerLabel.text = "Data Collecting (\(selectedTraitTitles.count)/\(maxTraitSelectionCount))"
     }
   }
 }


### PR DESCRIPTION
## 변경 사항
### 1. buttonCollectionView의 초기화는 필수요소만 간소하게 진행하고, setStyle에서 설정.

### 2. 변수 이름 변경
- `selectedTraitsTitles` -> `selectedTraitTitles`
- `maxSelectableTraits` -> `maxTraitSelectionCount`
- `name` -> `categoryName`

### 3. 전체적인 코드 순서
Components -> Properties -> Initializer -> UISetup -> Extension CollectionView(DataSource, Delegate) -> UICollectionFlowLayout -> UICollectionViewCell

### 4. 버튼 선택 / 해제 흐름
(1)  **버튼 터치**
(2)  **`didSelectItemAt` 메서드 호출** (indexPath를 통해 셀 정보 가져옴)
(3) **해당 `trait.name`이 `selectedTraitTitles`에 포함되어 있는지 확인.**
> **포함돼있다면?**
 -> **버튼 해제 로직 진행** : `selectedTraitTitles`에서 `trait.name` 삭제 + 부모뷰의 `updateSelectedTraitCount`호출해서 해당 trait의 count -1
 **포함 안 돼있다면?**
> -> **버튼 선택 로직 진행** : `selectedTraitTitles`에 `trait.name` 추가 + 부모뷰의 `updateSelectedTraitCount`호출해서 해당 trait의 count +1

(4) **UI업데이트**
> 셀의 UI 새로고침: collectionView.reloadItems(at: [indexPath])
> 푸터라벨 업데이트: updateFooterLabel()
> done버튼 상태 업데이트: parentViewController?.updateDoneButtonState()

---
현재 코드는 didSelect에서 버튼 선택 및 해제 로직을 모두 실행하기 때문에,
선택은 didSelect, 해제는 didDeselect로 로직을 나누어 실행하려고 했지만, didDeselect가 자동으로 호출이 안돼서 원래 방식대로 했습니다..
혹시 didDeselect는 원래 잘 쓰지 않나요 ?? ?아니면 이렇게 사용하는게 아닌가요..

---
++ 현재 FeedbackDetailViewController는 FeedbackSelectionComponent의 변수명 수정만 반영된 코드입니다!
FeedbackDetailViewController 코드는 다음 브랜치에서 리팩토링 진행하겠습니다~!

close #33 
